### PR TITLE
Fix player velocity

### DIFF
--- a/Assets/Custom Assets/Materials/Asteroids/Mat_Rock_Grey.mat
+++ b/Assets/Custom Assets/Materials/Asteroids/Mat_Rock_Grey.mat
@@ -92,7 +92,7 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.6886792, g: 0.6886792, b: 0.6886792, a: 1}
+    - _Color: {r: 0.3301887, g: 0.3301887, b: 0.3301887, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _FresnelColor: {r: 1, g: 1, b: 1, a: 1}
     - _HighColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Custom Assets/Prefabs/Player Ship.meta
+++ b/Assets/Custom Assets/Prefabs/Player Ship.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 11def4f3fad75ff4593956da401a6f3d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Package Imports/AsteroidsDemo.unitypackage.meta
+++ b/Assets/Package Imports/AsteroidsDemo.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: bd3fc27008dba78468f00e782d46599d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Package Imports/SpaceShooterProto.unitypackage.meta
+++ b/Assets/Package Imports/SpaceShooterProto.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 73882b56b1273ca428cc0f890f2a3e25
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -81,6 +81,10 @@ public class PlayerController : MonoBehaviour
 
     private void RaiseMaximumVelocity()
     {
-        player.stats.currentMaximumVelocity++;
+        if(player.stats.currentMaximumVelocity < player.stats.velocityCap)
+        {
+            player.stats.currentMaximumVelocity++;
+        }
+        
     }
 }

--- a/Assets/Scripts/Game Elements/Components/Collectables/Resources.meta
+++ b/Assets/Scripts/Game Elements/Components/Collectables/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b5aa8b15dc70e5346bf56311acc13f3e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Scriptable Objects/PlayerStats.cs
+++ b/Assets/Scripts/Scriptable Objects/PlayerStats.cs
@@ -94,6 +94,11 @@ public class PlayerStats : ScriptableObject
     public float currentMaximumVelocity;
 
     /// <summary>
+    /// This caps the velocity to an amount that the player absolutely cannot go beyond.
+    /// </summary>
+    public float velocityCap;
+
+    /// <summary>
     /// Base maneuvering speed pertains to how fast the player can move left and right to avoid collisions, without modifiers taken into account
     /// </summary>
     public float baseManeuveringSpeed;


### PR DESCRIPTION
- Implements new player stat, velocityCap, to put an absolute maximum on player velocity. This fixes the unintended behaviour whereby the player currentMaximumVelocity continues to go up but isn't ever stopped by an upward cap.
- Updates PlayerController script to incorporate this solution.