### PR TITLE
Implement rigidbody controller for player - first pass

### DIFF
--- a/Assets/Custom Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Custom Assets/Prefabs/Player/Player.prefab
@@ -693,7 +693,7 @@ GameObject:
   - component: {fileID: 2349310940658917947}
   - component: {fileID: 2349310940658917940}
   - component: {fileID: 2349310940658917941}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Shield
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -789,7 +789,7 @@ GameObject:
   - component: {fileID: 2349310940686075347}
   - component: {fileID: 2349310940686075345}
   - component: {fileID: 2349310940686075344}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: Player
   m_TagString: Player
   m_Icon: {fileID: 0}
@@ -840,16 +840,6 @@ MonoBehaviour:
   vfxParent: {fileID: 2344879991963761604}
   activeEnginesFx: {fileID: 7539312131535729061}
   inactiveEnginesFx: {fileID: 498689986292496399}
-  healHullFx: {fileID: 1753491271562446640, guid: 5fee70bc3b141ed4188a625cc4fa911e,
-    type: 3}
-  healArmourFx: {fileID: 5123891127911671129, guid: 9ffdba3aed7ed424492621825939ad16,
-    type: 3}
-  healShieldAuraFx: {fileID: 2719622899003654772, guid: e30efacdbc715344aae279887093d0d3,
-    type: 3}
-  speedMitigationFx: {fileID: 0}
-  maneuveringBoostFx: {fileID: 0}
-  spreadshotFx: {fileID: 0}
-  heatSinkFx: {fileID: 0}
 --- !u!114 &2349310940686075340
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -866,6 +856,10 @@ MonoBehaviour:
   horizontalSpeed: 50
   minX: -110
   maxX: 110
+  horizontalMove: 0
+  horizontalDrag: 0
+  maxHorizontalVelocity: 0
+  forceMultiplier: 0
 --- !u!54 &2349310940686075341
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Custom Assets/Prefabs/Powerups/Base/ArmourPowerup.prefab
+++ b/Assets/Custom Assets/Prefabs/Powerups/Base/ArmourPowerup.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7733160280928503641}
   - component: {fileID: 8626822248758798520}
   - component: {fileID: -4551242743148123931}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: ArmourPowerup
   m_TagString: Powerup
   m_Icon: {fileID: 0}
@@ -122,10 +122,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8883703168703204450}
     m_Modifications:
+    - target: {fileID: 776489167736633906, guid: 4658cc616401ffd45970e68b5c184573,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 776819731286122122, guid: 4658cc616401ffd45970e68b5c184573,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 776826793688906342, guid: 4658cc616401ffd45970e68b5c184573,
         type: 3}
       propertyPath: m_Name
       value: HealthArmourFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 776826793688906342, guid: 4658cc616401ffd45970e68b5c184573,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 780230154260433642, guid: 4658cc616401ffd45970e68b5c184573,
         type: 3}

--- a/Assets/Custom Assets/Prefabs/Powerups/Base/HullPowerup.prefab
+++ b/Assets/Custom Assets/Prefabs/Powerups/Base/HullPowerup.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7733160280928503641}
   - component: {fileID: 8626822248758798520}
   - component: {fileID: -1110722918416269063}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: HullPowerup
   m_TagString: Powerup
   m_Icon: {fileID: 0}
@@ -122,10 +122,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8883703168703204450}
     m_Modifications:
+    - target: {fileID: 3666180581548909597, guid: 5bd77bf77f41002438dc330a97fcdec6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 3666370736074531913, guid: 5bd77bf77f41002438dc330a97fcdec6,
         type: 3}
       propertyPath: m_Name
       value: HealthHullFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 3666370736074531913, guid: 5bd77bf77f41002438dc330a97fcdec6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 3666377006055669925, guid: 5bd77bf77f41002438dc330a97fcdec6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 3672025966193202373, guid: 5bd77bf77f41002438dc330a97fcdec6,
         type: 3}

--- a/Assets/Custom Assets/Prefabs/Powerups/Base/ManeuveringPowerup.prefab
+++ b/Assets/Custom Assets/Prefabs/Powerups/Base/ManeuveringPowerup.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7733160280928503641}
   - component: {fileID: 8626822248758798520}
   - component: {fileID: 783696956647853633}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: ManeuveringPowerup
   m_TagString: Powerup
   m_Icon: {fileID: 0}
@@ -177,10 +177,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5984514553915935502, guid: 84671be148b3d904382bffd93ca7c4a0,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984582628246780230, guid: 84671be148b3d904382bffd93ca7c4a0,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 5984622219982600034, guid: 84671be148b3d904382bffd93ca7c4a0,
         type: 3}
       propertyPath: m_Name
       value: ManeuveringPowerupFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984622219982600034, guid: 84671be148b3d904382bffd93ca7c4a0,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 84671be148b3d904382bffd93ca7c4a0, type: 3}

--- a/Assets/Custom Assets/Prefabs/Powerups/Base/ShieldPowerup.prefab
+++ b/Assets/Custom Assets/Prefabs/Powerups/Base/ShieldPowerup.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7733160280928503641}
   - component: {fileID: 8626822248758798520}
   - component: {fileID: -5644022283112225451}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: ShieldPowerup
   m_TagString: Powerup
   m_Icon: {fileID: 0}
@@ -179,10 +179,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1518544340759226725, guid: 408e2414fd02daa48832c245c775740c,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518700087865347549, guid: 408e2414fd02daa48832c245c775740c,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 1518706047535442225, guid: 408e2414fd02daa48832c245c775740c,
         type: 3}
       propertyPath: m_Name
       value: HealthShieldFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518706047535442225, guid: 408e2414fd02daa48832c245c775740c,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 408e2414fd02daa48832c245c775740c, type: 3}

--- a/Assets/Custom Assets/Prefabs/Powerups/Base/SpeedPowerup.prefab
+++ b/Assets/Custom Assets/Prefabs/Powerups/Base/SpeedPowerup.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7733160280928503641}
   - component: {fileID: 8626822248758798520}
   - component: {fileID: -7737160104356408364}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: SpeedPowerup
   m_TagString: Powerup
   m_Icon: {fileID: 0}
@@ -177,10 +177,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5984514553915935502, guid: 637ed8074da3ea941b4c1227c2bc2712,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984582628246780230, guid: 637ed8074da3ea941b4c1227c2bc2712,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 5984622219982600034, guid: 637ed8074da3ea941b4c1227c2bc2712,
         type: 3}
       propertyPath: m_Name
       value: SpeedPowerupFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984622219982600034, guid: 637ed8074da3ea941b4c1227c2bc2712,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 637ed8074da3ea941b4c1227c2bc2712, type: 3}

--- a/Assets/Custom Assets/Prefabs/Prototyping/Powerups.meta
+++ b/Assets/Custom Assets/Prefabs/Prototyping/Powerups.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 10e9a1ba420c0824dadec3343ee41c95
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Custom Assets/Prefabs/VFX/PlasmaShot.prefab
+++ b/Assets/Custom Assets/Prefabs/VFX/PlasmaShot.prefab
@@ -13,7 +13,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1923526610019734, guid: 359f5b6f28e085941a89ec70fa67ef0d, type: 3}
       propertyPath: m_Name
-      value: TestPlasma
+      value: PlasmaShot
       objectReference: {fileID: 0}
     - target: {fileID: 4977486018297876, guid: 359f5b6f28e085941a89ec70fa67ef0d, type: 3}
       propertyPath: m_RootOrder
@@ -394,7 +394,7 @@ PrefabInstance:
     - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
         type: 3}
       propertyPath: InheritVelocityModule.m_Mode
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
         type: 3}
@@ -404,7 +404,7 @@ PrefabInstance:
     - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
         type: 3}
       propertyPath: InheritVelocityModule.enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
         type: 3}
@@ -440,6 +440,11 @@ PrefabInstance:
         type: 3}
       propertyPath: InheritVelocityModule.m_Curve.scalar
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
+        type: 3}
+      propertyPath: InheritVelocityModule.m_Curve.minMaxState
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 198920213253613272, guid: 359f5b6f28e085941a89ec70fa67ef0d,
         type: 3}

--- a/Assets/Package Imports.meta
+++ b/Assets/Package Imports.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 10bbc0c9d7e0a6342b99fe9ff18834a1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/PrototypeLevel.unity
+++ b/Assets/Scenes/PrototypeLevel.unity
@@ -1769,6 +1769,31 @@ PrefabInstance:
       propertyPath: joystick
       value: 
       objectReference: {fileID: 69071898}
+    - target: {fileID: 2349310940686075340, guid: 2fddc4c8b71f41e46bc96011ac645d13,
+        type: 3}
+      propertyPath: horizontalDrag
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 2349310940686075340, guid: 2fddc4c8b71f41e46bc96011ac645d13,
+        type: 3}
+      propertyPath: forceMultiplier
+      value: 10000
+      objectReference: {fileID: 0}
+    - target: {fileID: 2349310940686075340, guid: 2fddc4c8b71f41e46bc96011ac645d13,
+        type: 3}
+      propertyPath: maxHorizontalVelocity
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 2349310940686075341, guid: 2fddc4c8b71f41e46bc96011ac645d13,
+        type: 3}
+      propertyPath: m_Mass
+      value: 5000
+      objectReference: {fileID: 0}
+    - target: {fileID: 2349310940686075341, guid: 2fddc4c8b71f41e46bc96011ac645d13,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 116
+      objectReference: {fileID: 0}
     - target: {fileID: 2349310940686075342, guid: 2fddc4c8b71f41e46bc96011ac645d13,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/Game Elements/Components/Hazards/Asteroid.cs
+++ b/Assets/Scripts/Game Elements/Components/Hazards/Asteroid.cs
@@ -60,7 +60,12 @@ public class Asteroid : Hazard
         {
             currentHealth = data.baseHealth;
         }
-        
+    }
+
+    public void MultiplyAsteroidMass()
+    {
+        Rigidbody rb = GetComponent<Rigidbody>();
+        rb.mass *= 40;
     }
 
     /// <summary>

--- a/Assets/Scripts/Utilities/ObjectPooler.cs
+++ b/Assets/Scripts/Utilities/ObjectPooler.cs
@@ -112,6 +112,7 @@ public class ObjectPooler : MonoBehaviour
             Asteroid asteroid = go.GetComponent<Asteroid>();
             ApplyAsteroidMaterial(asteroid);
             asteroid.SetAsteroidHealth();
+            asteroid.MultiplyAsteroidMass();
         }
 
         //pooledGasClouds = new List<GameObject>();


### PR DESCRIPTION
- Implements first pass rigidbody controller, which applies force to the player ship when input is detected.
- When no input is detected, drag will be applied to the player to gently stop them from sliding horizontally (was not a good effect).
- Due to the need to implement a physics material on the player ship, this commit moves Powerups onto their own layer. This should resolve the double-trigger enter firing identified as a bug in a previous build.

Drag still requires some tweaking, as it makes initial input "sticky" & doesn't feel good.